### PR TITLE
Add jinja2 requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ black
 pytest
 flask
 pprint
+jinja2


### PR DESCRIPTION
While building this project I noticed that your `requirements` file lacks `jinja2` and you running `make rule F_NAME=new-rule` command causes error. This should fix that.