### PR TITLE
Fix string validator regex rule pipe parsing

### DIFF
--- a/tests/rules/test_regex.py
+++ b/tests/rules/test_regex.py
@@ -37,6 +37,10 @@ def test_regex_03_string():
 
     assert validate({"val": "dcdcdc"}, {"val": "regex:(dc)*"})
 
+    assert validate({"val": "dcdcdc"}, {"val": "required|regex:(dc|ab)*"})
+
+    assert not validate({"val": "foobar"}, {"val": "regex:foo(baz|foo)$"})
+
     assert not validate({"val": "groy"}, {"val": "regex:gr[ae]y"})
 
     assert not validate({"val": "xyzabc"}, {"val": "regex:xyz$"})

--- a/utils/generate_rules_import.py
+++ b/utils/generate_rules_import.py
@@ -10,7 +10,7 @@ line = f"from {rules_pkg_path} import Rule\n"
 rules_file.writelines(line)
 
 # import __all__ object
-line = f"from {rules_pkg_path} import __all__\n"
+line = f"from {rules_pkg_path} import __all__, rules_with_args\n"
 rules_file.writelines(line)
 
 # import all rules from rules_src module

--- a/validator/parser/translator.py
+++ b/validator/parser/translator.py
@@ -49,13 +49,18 @@ class Translator:
         return rules_arr
 
     def _value_to_array(self):
-        # if value is string transform to string
+        # if value is string transform to list
         if isinstance(self.value, str):
             # list of rule str
             # suffix of pattern ensures regex-related `|` are not split upon
-            # splits on `|` only if it's followed by a validator rule + ":"
+            # splits on `|` only if it's followed by a validator rule without args
+            # or a validator rule that requires args + ":"
+            rules_with_args = ":|".join(R.rules_with_args)
+            rules_no_args = "|".join([rule for rule in list(R.__all__.keys()) if rule not in R.rules_with_args])
+            pattern = "[" + target_regex + f"](?={rules_with_args + ':|' + rules_no_args})"
+            
             return re.split(
-                "[" + target_regex + f"](?=({':|'.join(R.__all__)}))", self.value
+                pattern, self.value
             )
 
         # if value is array return
@@ -87,7 +92,7 @@ class Translator:
 
         # Remove underscore from class string ('ip_v4' will be same as 'ipv4')
         class_str = class_str.replace("_", "")
-
+        
         # Check if class string is in the list
         if not class_str in R.__all__:
             raise exc.NoRuleError

--- a/validator/parser/translator.py
+++ b/validator/parser/translator.py
@@ -51,7 +51,12 @@ class Translator:
     def _value_to_array(self):
         # if value is string transform to string
         if isinstance(self.value, str):
-            return re.split("[" + target_regex + "]", self.value)
+            # list of rule str
+            # suffix of pattern ensures regex-related `|` are not split upon
+            # splits on `|` only if it's followed by a validator rule + ":"
+            return re.split(
+                "[" + target_regex + f"](?=({':|'.join(R.__all__)}))", self.value
+            )
 
         # if value is array return
         if isinstance(self.value, list):
@@ -74,7 +79,6 @@ class Translator:
         if target_char in elem:
             # extract rule_name and arguments from string
             class_str, args_str = elem.split(target_char, 1)
-
             class_str = class_str.lower()
             # Split arguments into array
             args = args_str.split(target_args)

--- a/validator/rules_src/__init__.py
+++ b/validator/rules_src/__init__.py
@@ -65,6 +65,7 @@ class Rule(metaclass=ABCMeta):
 
 # Iterate each module in the given package and fill __all__ dictionary
 __all__ = {}
+rules_with_args = []
 for (_, file, _) in pkgutil.iter_modules([str(Path(__file__).parent)]):
     # Get Absolute Path
     module_abs_path = f"validator.rules_src.{file}"
@@ -81,5 +82,8 @@ for (_, file, _) in pkgutil.iter_modules([str(Path(__file__).parent)]):
         if "aliases" in rule_class.__dict__:
             for alias in rule_class.aliases:
                 __all__.update({alias.lower(): rule_class})
+
+        if len(rule_class.__init__.__code__.co_varnames) > 1:
+            rules_with_args.append(i.lower())
 
         __all__.update({i.lower(): rule_class})


### PR DESCRIPTION
Fixes issue #131 

- Changes how the translator parses string rules within the _value_to_array() function. 
- Uses a special regex pattern for parsing `regex:` rules to prevent the regex-related pipes from being detected as separate validator rules. 
- This approach of not splitting on every pipe `|` will cause inaccurate parsings of the rules if the following rule that precedes the regex rule has an invalid name (e.g. rule: `regex:foo|invalid_rule:arg` will parse the rule as is `["regex:foo|invalid_rule:arg"]` instead of the expected value of `["regex:foo", "invalid_rule:arg"]`